### PR TITLE
Add GitHub Actions configuration file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: CI
+
+on:
+    push:
+        branches: '*'
+    pull_request:
+        branches: '*'
+
+jobs:
+  perl-job:
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-latest, macos-latest]
+        # TODO: enable windows: , windows-latest
+        perl: [ '5.30' ]
+
+    runs-on: ${{matrix.runner}}
+    name: OS ${{matrix.runner}} Perl ${{matrix.perl}}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up perl
+      uses: shogo82148/actions-setup-perl@v1
+      with:
+          perl-version: ${{ matrix.perl }}
+          distribution: strawberry
+
+    - name: Install dependencies
+      run: |
+          cpanm --installdeps .
+
+    - name: Show content of log files on Linux
+      if: ${{ failure() && startsWith( matrix.runner, 'ubuntu-' )  }}
+      run: cat /home/runner/.cpanm/work/*/build.log
+
+    - name: Show content of log files on Mac
+      if: ${{ failure() && startsWith( matrix.runner, 'macos-' )  }}
+      run: cat /Users/runner/.cpanm/work/*/build.log
+
+    - name: Show content of log files on Windows
+      if: ${{ failure() && startsWith( matrix.runner, 'windows-' )  }}
+      run: cat C:/Users/RUNNER~1/.cpanm/work/*/build.log
+
+    - name: Regular Tests
+      run: |
+          perl Makefile.PL
+          make
+          make test
+
+
+    - name: Extra Tests
+      run: |
+          cpanm Test::CPAN::Changes Test::Pod::Coverage Test::Spelling Test::Pod
+          perl Makefile.PL
+          make
+          make test
+


### PR DESCRIPTION
The CI  was disabled on Windows as the tests fail See report https://github.com/szabgab/perl-Package-Role-ini/runs/1408504268?check_suite_focus=true

As far as I can see these are new tests, that will also fail on the computers of the users and the CPAN Testers.
So if you accept this PR you should probably enable the Windows environment as well and fix the tests.